### PR TITLE
Fix backup overwrite logic

### DIFF
--- a/ChroniQuill/EditorView.swift
+++ b/ChroniQuill/EditorView.swift
@@ -384,7 +384,12 @@ struct EditorView: View {
     private func createBackup(for file: URL) {
         let backupURL = file.deletingPathExtension().appendingPathExtension("_old.md")
         do {
-            try FileManager.default.copyItem(at: file, to: backupURL)
+            // Overwrite any existing backup so it always mirrors the last saved state
+            let fm = FileManager.default
+            if fm.fileExists(atPath: backupURL.path) {
+                try fm.removeItem(at: backupURL)
+            }
+            try fm.copyItem(at: file, to: backupURL)
 #if DEBUG
             print("📦 Backup created for: \(file.lastPathComponent)")
 #endif


### PR DESCRIPTION
## Summary
- prevent backup file creation from failing when it already exists

## Testing
- `swiftc -parse ChroniQuill/EditorView.swift`

------
https://chatgpt.com/codex/tasks/task_e_6846137e1a4c83338d8304297c77f64d