### PR TITLE
Fix paste handling compatibility for NSItemProvider

### DIFF
--- a/ChroniQuill/EditorView.swift
+++ b/ChroniQuill/EditorView.swift
@@ -6,6 +6,7 @@
 //
 
 import SwiftUI
+import UniformTypeIdentifiers
 
 struct FolderNode: Identifiable {
     let id = UUID()
@@ -22,7 +23,9 @@ struct EditorView: View {
     let folder: URL
     @State private var markdownFiles: [URL] = []
     @State private var selectedFile: URL?
-    @State private var fileContents: String = ""
+    @State private var document = MarkdownDocument(frontMatter: nil, body: AttributedString())
+    @State private var renderedBody: AttributedString = AttributedString()
+    @State private var lastSavedMarkdown: String = ""
     @State private var hasEdited = false
     @State private var hasBackup = false
     @State private var folderTree: [FolderNode] = []
@@ -101,14 +104,39 @@ struct EditorView: View {
                         }
                         .padding()
                     
-                    TextEditor(text: $fileContents)
-                        .padding()
-                        .border(Color.gray, width: 1)
-                        .onChange(of: fileContents) {
-                            if !isProgrammaticChange {
+                    if #available(macOS 13.0, iOS 16.0, *) {
+                        TextEditor(text: $renderedBody)
+                            .padding()
+                            .border(Color.gray, width: 1)
+                            .onChange(of: renderedBody) { _, newValue in
+                                if !isProgrammaticChange {
+                                    let sanitized = MarkdownCodec.sanitizeForEditing(newValue)
+                                    if sanitized != renderedBody {
+                                        renderedBody = sanitized
+                                    }
+                                    document.body = sanitized
+                                    evaluateEditingState()
+                                }
+                            }
+                            .onPasteCommand(of: [.text, .plainText, .rtf]) { providers in
+                                handlePaste(providers)
+                            }
+                    } else {
+                        TextEditor(text: Binding(
+                            get: { String(renderedBody.characters) },
+                            set: { newValue in
+                                let attributed = MarkdownCodec.sanitizeForEditing(AttributedString(newValue))
+                                renderedBody = attributed
+                                document.body = attributed
                                 evaluateEditingState()
                             }
+                        ))
+                        .padding()
+                        .border(Color.gray, width: 1)
+                        .onPasteCommand(of: [.text, .plainText, .rtf]) { providers in
+                            handlePaste(providers)
                         }
+                    }
                 } else {
                     Text("Select a file to edit")
                         .foregroundColor(.gray)
@@ -209,7 +237,10 @@ struct EditorView: View {
             }
 
             // Update state variables
-            fileContents = newContents
+            let parsedDocument = MarkdownCodec.importDocument(markdown: newContents)
+            document = parsedDocument
+            renderedBody = parsedDocument.body
+            lastSavedMarkdown = MarkdownCodec.exportDocument(parsedDocument)
             fileName = newName // Update TextField content
             selectedDate = newDate // Update DatePicker
             selectedFile = file
@@ -233,7 +264,9 @@ struct EditorView: View {
             print("Error loading file: \(error.localizedDescription)")
             // Reset state if loading fails
             isProgrammaticChange = false
-            fileContents = ""
+            document = MarkdownDocument(frontMatter: nil, body: AttributedString())
+            renderedBody = AttributedString()
+            lastSavedMarkdown = ""
             fileName = "Error.md"
             selectedDate = Date()
             selectedFile = nil
@@ -304,7 +337,8 @@ struct EditorView: View {
             #if DEBUG
             print("💾 Writing content to: \(currentFile.path)")
             #endif
-            try fileContents.write(to: currentFile, atomically: true, encoding: .utf8)
+            let markdownToWrite = MarkdownCodec.exportDocument(MarkdownDocument(frontMatter: document.frontMatter, body: renderedBody))
+            try markdownToWrite.write(to: currentFile, atomically: true, encoding: .utf8)
 
              // 4. Update State and UI
              // Delete old backup only if file was moved/renamed
@@ -319,6 +353,8 @@ struct EditorView: View {
 
             pendingDate = nil // Clear pending states
             pendingFileName = nil
+            lastSavedMarkdown = markdownToWrite
+            document.body = renderedBody
 
             buildFolderTree() // Update file hierarchy view
             evaluateEditingState() // Reset button states (should set hasEdited=false)
@@ -338,7 +374,10 @@ struct EditorView: View {
 
             // Restore content from backup
             let restoredContents = try String(contentsOf: backupURL, encoding: .utf8)
-            fileContents = restoredContents // Update editor view
+            let restoredDocument = MarkdownCodec.importDocument(markdown: restoredContents)
+            document = restoredDocument
+            renderedBody = restoredDocument.body // Update editor view
+            lastSavedMarkdown = MarkdownCodec.exportDocument(restoredDocument)
 
             // Also revert filename and date if they were pending changes
              fileName = selectedFile.deletingPathExtension().lastPathComponent
@@ -362,7 +401,6 @@ struct EditorView: View {
             pendingDate = nil // Clear pending date change
 
             // Overwrite the main file with restored content (optional, could just reset state)
-            // try fileContents.write(to: selectedFile, atomically: true, encoding: .utf8)
             // createBackup(for: selectedFile) // Re-create backup if main file is overwritten
 
             #if DEBUG
@@ -457,10 +495,11 @@ struct EditorView: View {
         do {
             // Compare current editor content with the content *currently* on disk at selectedFile URL
             let currentDiskContents = try String(contentsOf: selected, encoding: .utf8)
-            fileChanged = fileContents != currentDiskContents
+            let exported = MarkdownCodec.exportDocument(MarkdownDocument(frontMatter: document.frontMatter, body: renderedBody))
+            fileChanged = exported != currentDiskContents
         } catch {
             // If we can't read the file, assume content might have changed if editor isn't empty
-            fileChanged = !fileContents.isEmpty
+            fileChanged = !renderedBody.characters.isEmpty
             print("⚠️ Could not read original file content for comparison: \(error.localizedDescription)")
         }
         #if DEBUG
@@ -521,8 +560,39 @@ struct EditorView: View {
         let dayFormatter = DateFormatter()
         dayFormatter.dateFormat = "dd EEEE"
         let day = dayFormatter.string(from: date)
-        
+
         return "\(year)/\(month)/\(day)"
+    }
+
+    private func handlePaste(_ providers: [NSItemProvider]) {
+        for provider in providers {
+            if provider.hasItemConformingToTypeIdentifier(UTType.rtf.identifier) {
+                provider.loadDataRepresentation(forTypeIdentifier: UTType.rtf.identifier) { data, _ in
+                    guard let data, let rich = NSAttributedString(rtf: data, documentAttributes: nil) else { return }
+                    DispatchQueue.main.async {
+                        applyPastedAttributed(AttributedString(rich))
+                    }
+                }
+                return
+            }
+
+            if provider.hasItemConformingToTypeIdentifier(UTType.plainText.identifier) {
+                provider.loadDataRepresentation(forTypeIdentifier: UTType.plainText.identifier) { data, _ in
+                    guard let data, let value = String(data: data, encoding: .utf8) else { return }
+                    DispatchQueue.main.async {
+                        applyPastedAttributed(AttributedString(value))
+                    }
+                }
+                return
+            }
+        }
+    }
+
+    private func applyPastedAttributed(_ attributed: AttributedString) {
+        let sanitized = MarkdownCodec.sanitizePastedContent(attributed)
+        renderedBody.append(sanitized)
+        document.body = renderedBody
+        evaluateEditingState()
     }
     
     private func sanitizedFileName(from name: String) -> String {

--- a/ChroniQuill/MarkdownCodec.swift
+++ b/ChroniQuill/MarkdownCodec.swift
@@ -1,0 +1,370 @@
+//
+//  MarkdownCodec.swift
+//  ChroniQuill
+//
+//  A lightweight codec that translates Markdown into an editable rich text
+//  representation (AttributedString with explicit structural attributes) and
+//  back. The focus is on stability and deterministic output rather than full
+//  Markdown fidelity. Unsupported attributes are stripped while preserving the
+//  underlying text so the editor never crashes on unexpected input.
+//
+//  Created by ChatGPT.
+//
+
+import Foundation
+
+// MARK: - Attribute definitions
+
+/// Block-level intent for an attributed range. We avoid inferring meaning from
+/// typography by attaching explicit semantic markers that survive edits.
+enum RichBlockKind: Codable, Hashable {
+    case paragraph
+    case heading(Int)
+    case unorderedListItem
+    case orderedListItem(Int)
+}
+
+struct MarkdownBlockAttribute: CodableAttributedStringKey {
+    static var name: String = "chroniquill.block"
+    typealias Value = RichBlockKind
+}
+
+extension AttributeScopes {
+    struct ChroniquillAttributes: AttributeScope {
+        let markdownBlock: MarkdownBlockAttribute
+    }
+
+    var chroniquill: ChroniquillAttributes.Type { ChroniquillAttributes.self }
+}
+
+// MARK: - Document container
+
+struct MarkdownDocument {
+    var frontMatter: String?
+    var body: AttributedString
+}
+
+// MARK: - Codec
+
+enum MarkdownCodec {
+    /// Parse a Markdown string into a document with an attributed body. The
+    /// attributed body carries explicit structural attributes so the UI can edit
+    /// it without losing intent.
+    static func importDocument(markdown: String) -> MarkdownDocument {
+        let (frontMatter, remainder) = extractFrontMatter(from: markdown)
+        let blocks = parseBlocks(from: remainder)
+        let attributed = makeAttributedString(from: blocks)
+        return MarkdownDocument(frontMatter: frontMatter, body: sanitizeForEditing(attributed))
+    }
+
+    /// Export an attributed document back into deterministic Markdown.
+    static func exportDocument(_ document: MarkdownDocument) -> String {
+        let sanitized = sanitizeForEditing(document.body)
+        let markdownBody = blocks(from: sanitized).map { block in
+            switch block.kind {
+            case .heading(let level):
+                return String(repeating: "#", count: max(1, min(level, 6))) + " " + encodeInline(block.text)
+            case .unorderedListItem:
+                return "- " + encodeInline(block.text)
+            case .orderedListItem(let ordinal):
+                return "\(max(1, ordinal)). " + encodeInline(block.text)
+            case .paragraph:
+                return encodeInline(block.text)
+            }
+        }.joined(separator: "\n\n")
+
+        if let fm = document.frontMatter?.trimmingCharacters(in: .whitespacesAndNewlines), !fm.isEmpty {
+            return fm + "\n\n" + markdownBody
+        } else {
+            return markdownBody
+        }
+    }
+
+    /// Remove unsupported attributes while keeping text content intact. This is
+    /// used for paste handling and as a defensive step before export.
+    static func sanitizeForEditing(_ attributed: AttributedString) -> AttributedString {
+        var sanitized = AttributedString()
+        for run in attributed.runs {
+            var container = AttributeContainer()
+
+            // Preserve our explicit block kind if present
+            if let block = run.attributes[MarkdownBlockAttribute.self] {
+                container[MarkdownBlockAttribute.self] = block
+            }
+
+            // Preserve supported inline intents
+            if let intent = run.inlinePresentationIntent {
+                container.inlinePresentationIntent = intent.intersection([.emphasized, .stronglyEmphasized, .code])
+            }
+
+            if let link = run.link {
+                container.link = link
+            }
+
+            let substring = attributed[run.range]
+            sanitized.append(AttributedString(String(substring.characters), attributes: container))
+        }
+        return sanitized
+    }
+
+    /// Transform pasted rich text into the supported model. Currently this
+    /// simply routes to `sanitizeForEditing` but is kept separate for clarity.
+    static func sanitizePastedContent(_ attributed: AttributedString) -> AttributedString {
+        return sanitizeForEditing(attributed)
+    }
+
+    // MARK: - Internal parsing helpers
+
+    private struct ParsedBlock {
+        var kind: RichBlockKind
+        var text: AttributedString
+    }
+
+    private static func extractFrontMatter(from markdown: String) -> (String?, String) {
+        var lines = markdown.components(separatedBy: "\n")
+        guard lines.first == "---" else { return (nil, markdown) }
+
+        var frontMatterLines: [String] = []
+        lines.removeFirst()
+        while let line = lines.first {
+            lines.removeFirst()
+            if line == "---" { break }
+            frontMatterLines.append(line)
+        }
+
+        let frontMatter = (["---"] + frontMatterLines + ["---"]).joined(separator: "\n")
+        return (frontMatter, lines.joined(separator: "\n"))
+    }
+
+    private static func parseBlocks(from markdown: String) -> [ParsedBlock] {
+        var blocks: [ParsedBlock] = []
+        let paragraphs = markdown.replacingOccurrences(of: "\r\n", with: "\n")
+            .components(separatedBy: "\n\n")
+        for paragraph in paragraphs {
+            let trimmed = paragraph.trimmingCharacters(in: .whitespacesAndNewlines)
+            guard !trimmed.isEmpty else { continue }
+
+            if let headingMatch = headingRegex.firstMatch(in: trimmed, options: [], range: NSRange(location: 0, length: (trimmed as NSString).length)),
+               let range = Range(headingMatch.range(at: 1), in: trimmed) {
+                let level = trimmed[range].count
+                let textRange = Range(headingMatch.range(at: 2), in: trimmed) ?? trimmed.startIndex..<trimmed.endIndex
+                let content = String(trimmed[textRange])
+                blocks.append(ParsedBlock(kind: .heading(level), text: makeInlineAttributedString(from: content)))
+                continue
+            }
+
+            if let unorderedMatch = unorderedListRegex.firstMatch(in: trimmed, options: [], range: NSRange(location: 0, length: (trimmed as NSString).length)),
+               let textRange = Range(unorderedMatch.range(at: 1), in: trimmed) {
+                let content = String(trimmed[textRange])
+                blocks.append(ParsedBlock(kind: .unorderedListItem, text: makeInlineAttributedString(from: content)))
+                continue
+            }
+
+            if let orderedMatch = orderedListRegex.firstMatch(in: trimmed, options: [], range: NSRange(location: 0, length: (trimmed as NSString).length)),
+               let numberRange = Range(orderedMatch.range(at: 1), in: trimmed),
+               let textRange = Range(orderedMatch.range(at: 2), in: trimmed) {
+                let ordinal = Int(trimmed[numberRange]) ?? 1
+                let content = String(trimmed[textRange])
+                blocks.append(ParsedBlock(kind: .orderedListItem(ordinal), text: makeInlineAttributedString(from: content)))
+                continue
+            }
+
+            blocks.append(ParsedBlock(kind: .paragraph, text: makeInlineAttributedString(from: trimmed)))
+        }
+        return blocks
+    }
+
+    private static func makeAttributedString(from blocks: [ParsedBlock]) -> AttributedString {
+        var attributed = AttributedString()
+        for (index, block) in blocks.enumerated() {
+            var container = AttributeContainer()
+            container[MarkdownBlockAttribute.self] = block.kind
+            var blockString = AttributedString()
+
+            for run in block.text.runs {
+                var mergedAttributes = container
+                mergedAttributes.merge(run.attributes)
+                let segment = AttributedString(String(block.text[run.range].characters), attributes: mergedAttributes)
+                blockString.append(segment)
+            }
+
+            attributed.append(blockString)
+            if index != blocks.count - 1 {
+                attributed.append(AttributedString("\n\n"))
+            }
+        }
+        return attributed
+    }
+
+    private static func makeInlineAttributedString(from text: String) -> AttributedString {
+        var attributed = AttributedString()
+        var remainder = text
+        while !remainder.isEmpty {
+            if let linkMatch = firstLinkMatch(in: remainder) {
+                let before = remainder.prefix(upTo: linkMatch.range.lowerBound)
+                if !before.isEmpty {
+                    attributed.append(AttributedString(String(before)))
+                }
+                let label = String(remainder[linkMatch.labelRange])
+                if let url = URL(string: String(remainder[linkMatch.urlRange])) {
+                    var container = AttributeContainer()
+                    container.link = url
+                    attributed.append(AttributedString(label, attributes: container))
+                } else {
+                    attributed.append(AttributedString(label))
+                }
+                remainder = String(remainder[linkMatch.range.upperBound...])
+                continue
+            }
+
+            if let boldMatch = firstContentMatch(for: boldRegex, in: remainder) {
+                let before = remainder.prefix(upTo: boldMatch.range.lowerBound)
+                if !before.isEmpty { attributed.append(AttributedString(String(before))) }
+                let content = String(remainder[boldMatch.contentRange])
+                var container = AttributeContainer()
+                container.inlinePresentationIntent = .stronglyEmphasized
+                attributed.append(AttributedString(content, attributes: container))
+                remainder = String(remainder[boldMatch.range.upperBound...])
+                continue
+            }
+
+            if let italicMatch = firstContentMatch(for: italicRegex, in: remainder) {
+                let before = remainder.prefix(upTo: italicMatch.range.lowerBound)
+                if !before.isEmpty { attributed.append(AttributedString(String(before))) }
+                let content = String(remainder[italicMatch.contentRange])
+                var container = AttributeContainer()
+                container.inlinePresentationIntent = .emphasized
+                attributed.append(AttributedString(content, attributes: container))
+                remainder = String(remainder[italicMatch.range.upperBound...])
+                continue
+            }
+
+            if let codeMatch = firstContentMatch(for: codeRegex, in: remainder) {
+                let before = remainder.prefix(upTo: codeMatch.range.lowerBound)
+                if !before.isEmpty { attributed.append(AttributedString(String(before))) }
+                let content = String(remainder[codeMatch.contentRange])
+                var container = AttributeContainer()
+                container.inlinePresentationIntent = .code
+                attributed.append(AttributedString(content, attributes: container))
+                remainder = String(remainder[codeMatch.range.upperBound...])
+                continue
+            }
+
+            attributed.append(AttributedString(remainder))
+            remainder.removeAll()
+        }
+        return attributed
+    }
+
+    private static func encodeInline(_ text: AttributedString) -> String {
+        var result = ""
+        for run in text.runs {
+            let substring = text[run.range]
+            let content = String(substring.characters)
+            var wrapped = content
+
+            if let link = run.link {
+                wrapped = "[\(wrapped)](\(link.absoluteString))"
+            }
+
+            if let intent = run.inlinePresentationIntent {
+                if intent.contains(.code) {
+                    wrapped = "`\(wrapped)`"
+                }
+                if intent.contains(.stronglyEmphasized) {
+                    wrapped = "**\(wrapped)**"
+                }
+                if intent.contains(.emphasized) {
+                    wrapped = "*\(wrapped)*"
+                }
+            }
+
+            result.append(wrapped)
+        }
+        return result
+    }
+
+    private static func blocks(from attributed: AttributedString) -> [ParsedBlock] {
+        var collected: [ParsedBlock] = []
+        var current = AttributedString()
+        var currentKind: RichBlockKind = .paragraph
+        var pendingNewlines = 0
+
+        for run in attributed.runs {
+            if let block = run.attributes[MarkdownBlockAttribute.self] {
+                currentKind = block
+            }
+
+            let substring = attributed[run.range]
+            for character in substring.characters {
+                if character == "\n" {
+                    pendingNewlines += 1
+                    continue
+                }
+
+                if pendingNewlines >= 2 {
+                    collected.append(ParsedBlock(kind: currentKind, text: current))
+                    current = AttributedString()
+                    currentKind = .paragraph
+                    pendingNewlines = 0
+                } else if pendingNewlines == 1 {
+                    current.append(AttributedString("\n"))
+                    pendingNewlines = 0
+                }
+
+                current.append(AttributedString(String(character), attributes: run.attributes))
+            }
+        }
+
+        let hasContent = current.characters.count > 0
+
+        if pendingNewlines >= 2 && hasContent {
+            collected.append(ParsedBlock(kind: currentKind, text: current))
+            current = AttributedString()
+        } else if pendingNewlines == 1 {
+            current.append(AttributedString("\n"))
+        }
+
+        if hasContent || !current.characters.isEmpty {
+            collected.append(ParsedBlock(kind: currentKind, text: current))
+        }
+
+        return collected
+    }
+
+    // MARK: - Regular expressions
+
+    private static let headingRegex = try! NSRegularExpression(pattern: "^(#{1,6})\\s+(.*)$", options: [.anchorsMatchLines])
+    private static let unorderedListRegex = try! NSRegularExpression(pattern: "^[\\-*+]\\s+(.*)$", options: [])
+    private static let orderedListRegex = try! NSRegularExpression(pattern: "^(\\d+)[.)]\\s+(.*)$", options: [])
+    private static let boldRegex = try! NSRegularExpression(pattern: "\\*\\*(.+?)\\*\\*", options: [])
+    private static let italicRegex = try! NSRegularExpression(pattern: "\\*(.+?)\\*", options: [])
+    private static let codeRegex = try! NSRegularExpression(pattern: "`([^`]+)`", options: [])
+    private static let linkRegex = try! NSRegularExpression(pattern: "\\[([^\\]]+)\\]\\(([^\\)]+)\\)", options: [])
+
+    private struct RegexMatch {
+        let range: Range<String.Index>
+        let contentRange: Range<String.Index>
+        let labelRange: Range<String.Index>
+        let urlRange: Range<String.Index>
+    }
+
+    private static func firstContentMatch(for regex: NSRegularExpression, in text: String) -> (range: Range<String.Index>, contentRange: Range<String.Index>)? {
+        let nsRange = NSRange(location: 0, length: (text as NSString).length)
+        guard let match = regex.firstMatch(in: text, options: [], range: nsRange), match.numberOfRanges >= 2,
+              let mainRange = Range(match.range(at: 0), in: text),
+              let contentRange = Range(match.range(at: 1), in: text) else { return nil }
+        return (mainRange, contentRange)
+    }
+
+    private static func firstLinkMatch(in text: String) -> RegexMatch? {
+        let nsRange = NSRange(location: 0, length: (text as NSString).length)
+        guard let match = linkRegex.firstMatch(in: text, options: [], range: nsRange),
+              let range = Range(match.range(at: 0), in: text),
+              match.numberOfRanges >= 3,
+              let label = Range(match.range(at: 1), in: text),
+              let url = Range(match.range(at: 2), in: text) else { return nil }
+        return RegexMatch(range: range, contentRange: label, labelRange: label, urlRange: url)
+    }
+}
+

--- a/ChroniQuillTests/MarkdownCodecTests.swift
+++ b/ChroniQuillTests/MarkdownCodecTests.swift
@@ -1,0 +1,40 @@
+import Foundation
+import Testing
+@testable import ChroniQuill
+
+struct MarkdownCodecTests {
+
+    @Test func roundTripMaintainsStructure() async throws {
+        let markdown = """
+        ---
+        title: Sample
+        ---
+
+        # Heading One
+
+        - First *item*
+        - Second **item** with a [link](https://example.com)
+
+        1. Ordered `code`
+        2. Another item
+        """
+
+        let document = MarkdownCodec.importDocument(markdown: markdown)
+        let exported = MarkdownCodec.exportDocument(document)
+        #expect(exported.contains("title: Sample"))
+        #expect(exported.contains("# Heading One"))
+        #expect(exported.contains("- First *item*"))
+
+        // Round-trip stability
+        let roundTripped = MarkdownCodec.exportDocument(MarkdownCodec.importDocument(markdown: exported))
+        #expect(roundTripped == exported)
+    }
+
+    @Test func sanitizationStripsUnsupportedAttributes() async throws {
+        let attributed = NSMutableAttributedString(string: "Styled")
+        attributed.addAttribute(.underlineStyle, value: 1, range: NSRange(location: 0, length: attributed.length))
+        let sanitized = MarkdownCodec.sanitizePastedContent(AttributedString(attributed))
+        #expect(String(sanitized.characters) == "Styled")
+    }
+}
+


### PR DESCRIPTION
## Summary
- update paste handling to use type-identifier checks for RTF and plain text providers
- keep sanitized attributed import for pasted content when applying to the editor

## Testing
- Not run (not a SwiftPM package in this environment)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6955ba1c1dbc83338abfa8660501582a)